### PR TITLE
Use the clean method on the form

### DIFF
--- a/shorty/forms.py
+++ b/shorty/forms.py
@@ -29,11 +29,12 @@ class ShortURLForm(forms.ModelForm):
 
         return path
 
-    def clean_override_existing(self):
-        redirect = self.cleaned_data['redirect']
-        override_existing = self.cleaned_data['override_existing']
+    def clean(self):
+        cleaned_data = super(ShortURLForm, self).clean()
+        redirect = cleaned_data.get('redirect')
+        override_existing = cleaned_data.get('override_existing')
 
-        if override_existing != '1':
+        if override_existing != '1' and redirect:
             short_urls = ShortURL.objects.filter(redirect=redirect)
             if short_urls:
                 self.data = self.data.copy()
@@ -41,7 +42,7 @@ class ShortURLForm(forms.ModelForm):
                 self.request.previous_short_urls = short_urls
                 raise forms.ValidationError('That URL has been shortened previously.')
 
-        return override_existing
+        return cleaned_data
 
     class Meta:
         model = ShortURL

--- a/shorty/tests.py
+++ b/shorty/tests.py
@@ -2,6 +2,7 @@
 
 from django.test import TestCase, Client
 from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
 
 import mock
 
@@ -121,3 +122,10 @@ class AuthenticatedUITestCase(UserTestCase):
         self.assertRedirects(response, '/admin/', fetch_redirect_response=False)
         response = self.client.post('/admin/delete/', {'id_short_url': id_short_url})
         self.assertEqual(response.status_code, 400)
+
+    def test_create_short_url(self):
+        form_url = reverse('home')
+        response = self.client.post(form_url, {
+            'redirect': 'http://example.com',
+        })
+        self.assertRedirects(response, form_url, fetch_redirect_response=False)


### PR DESCRIPTION
As per https://docs.djangoproject.com/en/1.9/ref/forms/validation/#cleaning-and-validating-fields-that-depend-on-each-other
use clean, as the redirect field may not have been cleaned before the override_existing one.

This was breaking for me locally, when I tried to test #23